### PR TITLE
Resolve issue #38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "luxon": "^3.4.4",
         "marked": "^5.1.2",
         "marked-gfm-heading-id": "^3.2.0",
-        "marked-highlight": "^2.1.2",
+        "marked-highlight": "=2.1.1",
         "marked-mangle": "^1.1.8",
         "marked-smartypants": "^1.1.7",
         "mime": "^3.0.0",
@@ -1869,11 +1869,11 @@
       }
     },
     "node_modules/marked-highlight": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.1.2.tgz",
-      "integrity": "sha512-LttLexvzVYbdCWcjx5Upevtm1RAQ2965DyRMWfKzhpWwORPLeJay5Gp8lC4OfMs56QyfV/zIYeknp4NbTAfD0A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.1.1.tgz",
+      "integrity": "sha512-ktdqwtBne8rim5mb+vvZ9FzElGFb+CHCgkx/g6DSzTjaSrVnxsJdSzB5YgCkknFrcOW+viocM1lGyIjC0oa3fg==",
       "peerDependencies": {
-        "marked": ">=4 <14"
+        "marked": ">=4 <13"
       }
     },
     "node_modules/marked-mangle": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceforge",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A static site generator forked from Wintersmith",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -54,7 +54,7 @@
     "luxon": "^3.4.4",
     "marked": "^5.1.2",
     "marked-gfm-heading-id": "^3.2.0",
-    "marked-highlight": "^2.1.2",
+    "marked-highlight": "=2.1.1",
     "marked-mangle": "^1.1.8",
     "marked-smartypants": "^1.1.7",
     "mime": "^3.0.0",

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -146,7 +146,7 @@ const parseMarkdown = (content: ContentPlugin, markdown: string, baseUrl: string
 
     const marked = new Marked(
         options, 
-        //highlightRoutine, 
+        highlightRoutine, 
         markedMangle(), 
         markedSmartypants(), 
         gfmHeadingId(headingIdOptions)


### PR DESCRIPTION
Marked-highlight v2.1.2 introduced support for marked v13, but appears to have accidentally broken support for versions of marked prior to v13.  This change pins marked-highlight to 2.1.1 until upstream is fixed and/or Iceforge supports marked v13.